### PR TITLE
Move PDF to old folder if changes are made

### DIFF
--- a/app/actions/iirActions.ts
+++ b/app/actions/iirActions.ts
@@ -376,11 +376,25 @@ export function postOrUpdateIIRReport(iirNotes: {
             dispatch(autoEmailer());
           };
         }
-        // Callback for autoEmailer and success modal only if the updated workOrder Info succuessfully updates state
-        dispatch(getIIRData(workOrder));
-
         // TODO: Setup move PDF if it exists.
         // When changes are made, need to move the current PDF out to prevent people pulling a none updated PDF.
+        if (state.diplayOpenPDFBtn) {
+          const dateTime = Date.now();
+          const workOrderString = `${state.workOrder.workOrderSearch}-${state.workOrder.workOrderSearchLineItem}`;
+          const oldPath = `\\\\AMR-FS1\\Scanned\\CPLT_TRAVELERS\\TearDowns\\${workOrderString}_TEAR_DOWN.pdf`;
+          const newPath = `\\\\AMR-FS1\\Scanned\\CPLT_TRAVELERS\\TearDowns\\old\\${workOrderString}_TEAR_DOWN_${dateTime}.pdf`;
+
+          fs.rename(oldPath, newPath, err => {
+            if (err) {
+              const returnError = {
+                error: `Couldn't move ${workOrderString}_TEAR_DOWN! Please move PDF to old folder!`
+              };
+              dispatch(toggleErrorModalState(returnError));
+            }
+          });
+        }
+        // Callback for autoEmailer and success modal only if the updated workOrder Info succuessfully updates state
+        dispatch(getIIRData(workOrder));
       } else {
         const returnError = { error: '' };
         if (Object.keys(resp.error).length > 1) {


### PR DESCRIPTION
Setup actions/iirActions in postOrUpdateIIRReport to move the PDF to an old folder with time stame if one exists.
This will prevent displaying outdated Tear Down PDF if updates are made.